### PR TITLE
v1.2 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,27 +2,33 @@
 
 A docker image which reads data from a Bosch BME680 atmospherics sensor, and sends the result to HomeAssistant via a MQTT broker.
 
-![Example HomeAssistant Device Page](assets/example-sensor-list.png) ![Example HomeAssistant Device Page](assets/example-device-page.png)
+| ![Example HomeAssistant Device Page](assets/example-sensor-list.png) | ![Example HomeAssistant Device Page](assets/example-device-page.png) |
+| :------------------------------------------------------------------: | :------------------------------------------------------------------: |
+|          An example taken from the HomeAssistant dashboard.          |              The device in HomeAssistant's device view.              |
 
 ## Example Compose File:
 
 This example compose specification can be used to run the docker container:
 
 > [!IMPORTANT]
-> This repository and its associated docker image is currently private. Make sure to sign in with `docker login` before attempting to pull the image.
+> This repository and its associated docker image are currently private. Make sure to sign in with `docker login` before attempting to pull the image.
 
 ```YAML
 services:
   bme680-mqtt:
-      image: ghcr.io/lillian-alicia/bme680-mqtt:1.0
+      image: ghcr.io/lillian-alicia/bme680-mqtt:1.0 # Select image version here
 
       volumes:
         - /dev/i2c-1:/dev/i2c-1 # Pass through the i2c device from the host.
 
       environment:
-        MQTT_ADDR: "example.broker.com"
+        MQTT_ADDR: 'example.broker.com'
         MQTT_PORT: 1883 # Port for the MQTT broker, defaults to 1883.
+        MQTT_AUTH_MODE: 'none' # Replace with 'env' or 'file' if desired - see docs.
         POLL_TIME: 60 # How often to send data via MQTT, in seconds.
+
+        MQTT_USERNAME: 'username' # The username and password for the MQTT
+        MQTT_PASSWORD: 'password' # broker if using MQTT_AUTH_MODE 'env'.
 
       privileged: true
 ```
@@ -31,7 +37,23 @@ services:
 
 An external MQTT broker is required in order for this container to send data to home assistant. This can be run locally as a container, on another host, or within homeassistant. I recommend using the [Eclipse Mosquitto](https://hub.docker.com/_/eclipse-mosquitto) broker, which can be run as a docker container.
 
-The broker must support retained messages, and not require authentication. (**Authentication via username and password coming soon.**)
+The broker must support retained messages, and Quality of Service level 2 (QOS).
+
+### Authentication
+
+This image supports both unauthenticated and authenticated connections to an MQTT broker, through the `MQTT_AUTH_MODE` environment variable (see [Environment Variables](README.md#environment-variables)).
+
+The authentication mode can be set to one of three options:
+
+- `none` - No authentication. Any provided credentials will be ignored.
+- `env` - Authentication credentials are supplied through environment variables (`MQTT_USERNAME` and `MQTT_PASSWORD`).
+- `file` - Authentication credentials are supplied in JSON format, in a file bind-mounted to the container.
+
+If using the `file` auth mode, the credentials should be supplied in the following format:
+
+```json
+{ "username": "USERNAME_HERE", "password": "YOUR_PASSWORD" }
+```
 
 ## HomeAssistant Discovery via MQTT
 
@@ -108,11 +130,21 @@ This docker image sends the following discovery message, which adds all of the d
 
 This docker image is designed to have user-friendly customisation. All of the necessary options are set using environment variables, and default to sane values.
 
+### Sensor Config
+
 - `I2C_ADDR` - The i2c address of the BME680 sensor. **Defaults to 0x76**, the standard address for i2C devices.
-- `MQTT_ADDR` - (**Mandatory**) The IP address or hostname for the MQTT broker (see [MQTT Broker](README.md#mqtt-broker) for more information.)
-- `MQTT_PORT` - The port that the MQTT broker communicates on. **Defaults to 1883**, the default port used for MQTT.
-- `MQTT_TOPIC` - The topic that MQTT messages containing sensor data are sent on. **Defaults to `bme680`**. This topic is automatically passed on to HomeAssistant when using discovery (see [Discovery](README.md#homeassistant-discovery-via-mqtt)).
 - `POLL_TIME` - How frequently to send sensor data to HomeAssistant, in seconds. **Defaults to 60s**.
+
+### MQTT Broker Config
+
+- `MQTT_ADDR` - (**REQUIRED**) The IP address or hostname for the MQTT broker (see [MQTT Broker](README.md#mqtt-broker) for more information.)
+- `MQTT_PORT` - The port that the MQTT broker communicates on. **Defaults to 1883**, the default port used for MQTT.
+- `MQTT_AUTH_MODE` - The authentication method used to connect to the MQTT broker. This can be `none`, `env`, or `file` (see [Authentication](README.md#authentication)).
+- `MQTT_USERNAME` **(OPTIONAL)**
+
+### MQTT Topics Config
+
+- `MQTT_TOPIC` - The topic that MQTT messages containing sensor data are sent on. **Defaults to `bme680`**. This topic is automatically passed on to HomeAssistant when using discovery (see [Discovery](README.md#homeassistant-discovery-via-mqtt)).
 - `DISCOVERY_TOPIC` - The topic used by HomeAssistant for discovery. The default topic used in a HomeAssistant installation is `homeassistant`, however it can be changed by the user.
 - `DEVICE_ID` - The device name given to HomeAssistant via discovery. Note that the **device name** in HomeAssistant will be this ID, and the **device ID** will be `BME680_{DEVICE_ID}`.
 
@@ -126,8 +158,3 @@ This project can be used to connect multiple BME680 sensors to HomeAssistant, pr
 
 **Coming Soon...**
 Disabling use with HomeAssistant's discovery feature will soon be available by passing an environment variable to this container.
-
-### Authentication to the MQTT Broker
-
-**Coming Soon...**
-Authentication to a MQTT broker via a username and password will soon be available, either by passing the username and password as environment variables, or by bind-mounting a password file into the container.

--- a/src/main.py
+++ b/src/main.py
@@ -40,7 +40,7 @@ def parseAuth(authData:str) -> dict[str, str] | None:
             return {    "username"  :   str(getenv("MQTT_USERNAME", "username")),
                         "password"  :   str(getenv("MQTT_PASSWORD", "password"))    }
         case "file":
-            with open("/bme680/auth", "r") as f:
+            with open("/bme680-mqtt/auth", "r") as f:
                 return load(f)
         case _: # else:
             raise ValueError(f"MQTT_AUTH_MODE must be one of 'none', 'env', or 'file', not '{MQTT_AUTH_MODE}'.")

--- a/src/main.py
+++ b/src/main.py
@@ -3,7 +3,6 @@ import asyncio
 import bme680
 import aiomqtt as mqtt
 from json import dumps, load
-from json import dumps, load
 from os import getenv
 from sys import stderr
 

--- a/src/main.py
+++ b/src/main.py
@@ -12,7 +12,7 @@ SW_VERSION = "1.1.1"
 
 # ----- Load configuration from environment variables -----
 # Sensor Config
-I2C_ADDR_PRIMARY = int(getenv("I2C_ADDR", 0x76))
+I2C_ADDR = int(getenv("I2C_ADDR", 0x76))
 POLL_TIME = int(getenv("POLL_TIME", 60))
 
 # MQTT Broker Config
@@ -128,9 +128,9 @@ def discoveryMessage() -> str:
 
 def initSensor() -> bme680.BME680:
     try:
-        sensor = bme680.BME680(I2C_ADDR_PRIMARY)
+        sensor = bme680.BME680(I2C_ADDR)
     except:
-        raise OSError(f"Failed to open i2c device at address '{I2C_ADDR_PRIMARY}'. Check the I2C_ADDR_PRIMARY environment variable.")
+        raise OSError(f"Failed to open i2c device at address '{I2C_ADDR}'. Check the I2C_ADDR_PRIMARY environment variable.")
 
     # Sensor configuration from pimoroni's examples:
     # https://github.com/pimoroni/bme680-python

--- a/src/main.py
+++ b/src/main.py
@@ -2,7 +2,7 @@
 import asyncio
 import bme680
 import aiomqtt as mqtt
-from json import dumps
+from json import dumps, load
 from os import getenv
 from sys import stderr
 
@@ -10,19 +10,39 @@ from sys import stderr
 SW_VERSION = "1.1.1"
 
 # ----- Load configuration from environment variables -----
+# Sensor Config
 I2C_ADDR_PRIMARY = int(getenv("I2C_ADDR", 0x76))
+POLL_TIME = int(getenv("POLL_TIME", 60))
+
+# MQTT Broker Config
 MQTT_ADDR = str(getenv("MQTT_ADDR", "127.0.0.1"))
 MQTT_PORT = int(getenv("MQTT_PORT", 1883))
+MQTT_AUTH_MODE = str(getenv("MQTT_AUTH_MODE", "none")) # Can be "none" (no auth needed), "env" (auth details in environment vars), or "file" (auth details in file at "/bme680/auth")
+
+# MQTT Topics Config
 MQTT_TOPIC = str(getenv("MQTT_TOPIC", "bme680"))
-POLL_TIME = int(getenv("POLL_TIME", 60))
 DISCOVERY_TOPIC = str(getenv("DISCOVERY_PREFIX", "homeassistant"))
 DEVICE_ID = str(getenv("DISCOVERY_DEVICE_ID", "bme680"))
 
-print("===================================================")
-print("|==============     BME680-MQTT     ==============|")
-print("|====  github.com/lillian-alicia/bme680-mqtt  ====|")
-print("===================================================")
+print("""
+|=================================================|
+|==============     BME680-MQTT     ==============|
+|====  github.com/lillian-alicia/bme680-mqtt  ====|
+===================================================""")
 # ----- Subprograms -----
+
+def parseAuth(authData:str) -> dict[str, str] | None:
+    match authData:
+        case "none":
+            return None
+        case "env":
+            return {    "username"  :   str(getenv("MQTT_USERNAME", "username")),
+                        "password"  :   str(getenv("MQTT_PASSWORD", "password"))    }
+        case "file":
+            with open("/bme680/auth", "r") as f:
+                return load(f)
+        case _: # else:
+            raise ValueError(f"MQTT_AUTH_MODE must be one of 'none', 'env', or 'file', not '{MQTT_AUTH_MODE}'.")
 
 def readData(sensor:bme680.BME680) -> str:
     sensor.get_sensor_data() # Pulls new data from the sensor
@@ -129,7 +149,11 @@ def initSensor() -> bme680.BME680:
 # ----- Main -----
 async def main():
     SENSOR = initSensor()
-    client = mqtt.Client(hostname=MQTT_ADDR, port=MQTT_PORT)
+    auth = parseAuth(MQTT_AUTH_MODE)
+    if auth == None:
+        client = mqtt.Client(hostname=MQTT_ADDR, port=MQTT_PORT) # Connect with no authentication details
+    else:
+        client = mqtt.Client(hostname=MQTT_ADDR, port=MQTT_PORT, username=auth["username"], password=auth["password"])
 
     # ----- HomeAssistant Discovery
     try:

--- a/src/main.py
+++ b/src/main.py
@@ -8,7 +8,7 @@ from os import getenv
 from sys import stderr
 
 # ----- Software Version (used in discovery)
-SW_VERSION = "1.1.1"
+SW_VERSION = "1.2"
 
 # ----- Load configuration from environment variables -----
 # Sensor Config

--- a/src/main.py
+++ b/src/main.py
@@ -3,6 +3,7 @@ import asyncio
 import bme680
 import aiomqtt as mqtt
 from json import dumps, load
+from json import dumps, load
 from os import getenv
 from sys import stderr
 
@@ -151,9 +152,9 @@ async def main():
     SENSOR = initSensor()
     auth = parseAuth(MQTT_AUTH_MODE)
     if auth == None:
-        client = mqtt.Client(hostname=MQTT_ADDR, port=MQTT_PORT) # Connect with no authentication details
+        client = mqtt.Client(hostname=MQTT_ADDR, port=MQTT_PORT, identifier=f"BME680_{DEVICE_ID}") # Connect with no authentication details
     else:
-        client = mqtt.Client(hostname=MQTT_ADDR, port=MQTT_PORT, username=auth["username"], password=auth["password"])
+        client = mqtt.Client(hostname=MQTT_ADDR, port=MQTT_PORT, username=auth["username"], password=auth["password"], identifier=f"BME680_{DEVICE_ID}")
 
     # ----- HomeAssistant Discovery
     try:

--- a/src/start.sh
+++ b/src/start.sh
@@ -4,5 +4,5 @@
 source /bme680-mqtt/.venv/bin/activate
 
 # Run python script
-python3 main.py
+python3 -u main.py
 


### PR DESCRIPTION
# v1.2
## Summary
- Added options to authenticate to an MQTT broker via a username and password. 
- FIXED missing logs in `docker logs` due to python running in buffered mode.
- Updated README.md to detail the changes.

## Changes:
### `main.py`:
- Added the `parseAuth()` function, which reads the `MQTT_AUTH_MODE` from the environment, and returns authentication credentials accordingly (see README.me for more information).
*NOTE: Non-breaking change, as `MQTT_AUTH_MODE` defaults to `none`, which uses no authentication.*

- Added login in `main()` to connect with auth credentials if provided.

- Updated `main()` to connect to the MQTT broker with a unique identifier, in the format `BME680_{DEVICE_ID}`, using the same *DEVICE_ID* provided to HomeAssistant during discovery.

- Changed the constant names in main.py to match the environment variable names used.

### `start.sh`
- Updated the python3 command to use unbuffered mode (`python3 -u main.py`), which fixed an issue where data sent to stdout (eg print statements) were not being shown in `docker logs`.

### `README.md`
- Added captions to the two example images. 

- Added documentation on the new authentication options, and removed authentication from the "Coming Soon" section.

- Updated the example `compose.yaml` to include the new authentication options, and added more comments.

- Split the Environment Variables section into subsections.

